### PR TITLE
Moved port setting to run-shingle

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,5 +106,6 @@ schingle (pronounced shingle) is a tiny web framework for guile inspired by
   (plain "oopsiedoo" #:code 404))
 
 (run-schingle #:middleware (list (make-cors-middleware))
+              #:port 8080 ; optional setting of port
               #:h404 custom404)
 ```

--- a/schingle.scm
+++ b/schingle.scm
@@ -99,7 +99,9 @@
 (define (schingle-handler)
   (routes->handler (routes)))
 
-(define* (run-schingle #:key (impl 'http) (open-params '())
+(define* (run-schingle #:key (impl 'http)
+                       (port 8080)
+                       (open-params `(#:port ,port))
                        (middleware '())
                        (h404 (404handler)) (h500 (500handler)) (h400 (400handler)))
   "convinience function that combines making the handler and starting the server."


### PR DESCRIPTION
Now you can go:
(run-schingle #:port 8000)
Instead of:
(run-schingle #:open-params '(#:port 8000))

This is much more intuitive, and shorter for a commonly configured
feature.

As well, instead of having to read the guile documentation for figuring out the default port, it's in the readme example